### PR TITLE
Fix the argument name for the committer info on svn_watcher and svnpoller

### DIFF
--- a/master/contrib/svn_watcher.py
+++ b/master/contrib/svn_watcher.py
@@ -46,7 +46,7 @@ def sendchange_cmd(master, revisionData):
         "sendchange",
         "--master=%s" % master,
         "--revision=%s" % revisionData['revision'],
-        "--username=%s" % revisionData['author'],
+        "--who=%s" % revisionData['author'],
         "--comments=%s" % revisionData['comments'],
         "--vc=%s" % 'svn',
     ]

--- a/master/contrib/svnpoller.py
+++ b/master/contrib/svnpoller.py
@@ -85,7 +85,7 @@ if lastrevision != revision:
 
     # comments = codecs.encodings.unicode_escape.encode(comments)
     cmd = "buildbot sendchange --master=" + buildmaster + " --branch=trunk \
---revision=\"" + revision + "\" --username=\"" + author + "\" --vc=\"svn\" \
+--revision=\"" + revision + "\" --who=\"" + author + "\" --vc=\"svn\" \
 --comments=\"" + comments + "\" " + " ".join(paths)
 
     # print cmd


### PR DESCRIPTION
"buildbot sendchange" expects an argument "--who" and not "--author"