### PR TITLE
Replace commands.getoutput with subprocess.check_output

### DIFF
--- a/master/contrib/bk_buildbot.py
+++ b/master/contrib/bk_buildbot.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import commands
+import subprocess
 import sys
 
 from twisted.cred import credentials
@@ -83,15 +83,19 @@ class ChangeSender:
         rev_arg = ''
         if opts['revision']:
             rev_arg = '-r"%s"' % (opts['revision'], )
-        changed = commands.getoutput("bk changes -v %s -d':GFILE:\\n' '%s'" % (
-            rev_arg, repo)).split('\n')
+        changed = subprocess.check_output("bk changes -v %s -d':GFILE:\\n' '%s'" % (
+            rev_arg, repo), shell=True)
+        changed = changed.decode(sys.stdout.encoding)
+        changed = changed.split('\n')
 
         # Remove the first line, it's an info message you can't remove
         # (annoying)
         del changed[0]
 
-        change_info = commands.getoutput("bk changes %s -d':USER:\\n$each(:C:){(:C:)\\n}' '%s'" % (
-            rev_arg, repo)).split('\n')
+        change_info = subprocess.check_output("bk changes %s -d':USER:\\n$each(:C:){(:C:)\\n}' '%s'" % (
+            rev_arg, repo), shell=True)
+        change_info = change_info.decode(sys.stdout.encoding)
+        change_info = change_info.split('\n')
 
         # Remove the first line, it's an info message you can't remove
         # (annoying)

--- a/master/contrib/darcs_buildbot.py
+++ b/master/contrib/darcs_buildbot.py
@@ -21,8 +21,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import commands
 import os
+import subprocess
 import sys
 import xml
 from xml.dom import minidom
@@ -85,7 +85,8 @@ def makeChange(p):
 
 
 def getChangesFromCommand(cmd, count):
-    out = commands.getoutput(cmd)
+    out = subprocess.check_output(cmd, shell=True)
+    out = out.decode(sys.stdout.encoding)
     try:
         doc = minidom.parseString(out)
     except xml.parsers.expat.ExpatError as e:
@@ -161,7 +162,8 @@ def sendChanges(master):
     # contexts is Hard.
 
     # get the context for the most recent change
-    latestcontext = commands.getoutput("darcs changes --context")
+    latestcontext = subprocess.check_output("darcs changes --context", shell=True)
+    latestcontext = latestcontext.decode(sys.stdout.encoding)
     changes[-1]['context'] = latestcontext
 
     def _send(res, c):

--- a/master/contrib/fakechange.py
+++ b/master/contrib/fakechange.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import commands
 import os.path
 import random
+import subprocess
 import sys
 
 from twisted.cred import credentials
@@ -71,7 +71,8 @@ def send_change(remote):
         files = sys.argv[1:]
     else:
         files = [makeFilename()]
-    comments = commands.getoutput("fortune")
+    comments = subprocess.check_output(["fortune"])
+    comments = comments.decode(sys.stdout.encoding)
     change = {'who': who, 'files': files, 'comments': comments}
     d = remote.callRemote('addChange', change)
     d.addCallback(done)

--- a/master/contrib/svn_buildbot.py
+++ b/master/contrib/svn_buildbot.py
@@ -21,10 +21,10 @@ from __future__ import division
 from __future__ import print_function
 from future.utils import text_type
 
-import commands
 import os
 import re
 import sets
+import subprocess
 import sys
 
 from twisted.cred import credentials
@@ -169,13 +169,17 @@ class ChangeSender:
         rev_arg = ''
         if opts['revision']:
             rev_arg = '-r %s' % (opts['revision'], )
-        changed = commands.getoutput('svnlook changed %s "%s"' % (
-            rev_arg, repo)).split('\n')
+        changed = subprocess.check_output('svnlook changed %s "%s"' % (
+            rev_arg, repo), shell=True)
+        changed = changed.decode(sys.stdout.encoding)
+        changed = changed.split('\n')
         # the first 4 columns can contain status information
         changed = [x[4:] for x in changed]
 
-        message = commands.getoutput('svnlook log %s "%s"' % (rev_arg, repo))
-        who = commands.getoutput('svnlook author %s "%s"' % (rev_arg, repo))
+        message = subprocess.check_output('svnlook log %s "%s"' % (rev_arg, repo), shell=True)
+        message = message.decode(sys.stdout.encoding)
+        who = subprocess.check_output('svnlook author %s "%s"' % (rev_arg, repo), shell=True)
+        who = who.decode(sys.stdout.encoding)
         revision = opts.get('revision')
         if revision is not None:
             revision = str(int(revision))

--- a/master/contrib/svnpoller.py
+++ b/master/contrib/svnpoller.py
@@ -23,9 +23,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import commands
 import ConfigParser
 import os.path
+import subprocess
+import sys
 import xml.dom.minidom
 
 # change these settings to match your project
@@ -33,8 +34,10 @@ svnurl = "https://pse.cheme.cmu.edu/svn/ascend/code/trunk"
 statefilename = "~/changemonitor/config.ini"
 buildmaster = "buildbot.example.org:9989"  # connects to a PBChangeSource
 
-xml1 = commands.getoutput(
-    "svn log --non-interactive --verbose --xml --limit=1 " + svnurl)
+xml1 = subprocess.check_output(
+    "svn log --non-interactive --verbose --xml --limit=1 " + svnurl,
+    shell=True)
+xml1 = xml1.decode(sys.stdout.encoding)
 # print "XML\n-----------\n"+xml1+"\n\n"
 
 try:
@@ -89,7 +92,8 @@ if lastrevision != revision:
 --comments=\"" + comments + "\" " + " ".join(paths)
 
     # print cmd
-    res = commands.getoutput(cmd)
+    res = subprocess.check_output(cmd)
+    res = res.decode(sys.stdout.encoding)
 
     print("SUBMITTING NEW REVISION", revision)
     if not ini.has_section("CurrentRevision"):


### PR DESCRIPTION
commands module is deprecated in Python 2, and gone in Python 3