### PR TITLE
Fix Popen usage in git_buildbot.py hook script.

### DIFF
--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -382,7 +382,7 @@ def process_changes():
 def send_changes():
     # Submit the changes, if any
     if not changes:
-        logging.warning("No changes found")
+        logging.info("No changes found")
         return
 
     host, port = master.split(':')

--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -249,7 +249,7 @@ def gen_create_tag_changes(newrev, refname, tag):
     f = subprocess.Popen(shlex.split("git log -n 1 --pretty=oneline %s" % newrev),
                          stdout=subprocess.PIPE)
     gen_changes(f, tag)
-    status = f.close()
+    status = f.returncode
     if status:
         logging.warning("git log exited with status %d", status)
 
@@ -292,7 +292,7 @@ def gen_update_branch_changes(oldrev, newrev, refname, branch):
             logging.debug("  Rewound file: %s", file)
             files.append(text_type(file))
 
-        status = f.terminate()
+        status = f.returncode
         if status:
             logging.warning("git diff exited with status %d", status)
 

--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -177,7 +177,7 @@ def grab_commit_info(c, rev):
 
     c['comments'] = ''.join(comments)
     c['files'] = files
-    status = f.terminate()
+    status = f.wait()
     if status:
         logging.warning("git show exited with status %d", status)
 
@@ -235,7 +235,7 @@ def gen_create_branch_changes(newrev, refname, branch):
 
     gen_changes(f3, branch)
 
-    status = f3.returncode
+    status = f3.wait()
     if status:
         logging.warning("git rev-list exited with status %d", status)
 
@@ -249,7 +249,7 @@ def gen_create_tag_changes(newrev, refname, tag):
     f = subprocess.Popen(shlex.split("git log -n 1 --pretty=oneline %s" % newrev),
                          stdout=subprocess.PIPE)
     gen_changes(f, tag)
-    status = f.returncode
+    status = f.wait()
     if status:
         logging.warning("git log exited with status %d", status)
 
@@ -292,7 +292,7 @@ def gen_update_branch_changes(oldrev, newrev, refname, branch):
             logging.debug("  Rewound file: %s", file)
             files.append(text_type(file))
 
-        status = f.returncode
+        status = f.wait()
         if status:
             logging.warning("git diff exited with status %d", status)
 
@@ -324,7 +324,7 @@ def gen_update_branch_changes(oldrev, newrev, refname, branch):
                              stdout=subprocess.PIPE)
         gen_changes(f, branch)
 
-        status = f.terminate()
+        status = f.wait()
         if status:
             logging.warning("git rev-list exited with status %d", status)
 

--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -436,7 +436,7 @@ def parse_options():
 # information to a file as well (we'll set that up later.)
 stderr = logging.StreamHandler(sys.stderr)
 fmt = logging.Formatter("git_buildbot: %(levelname)s: %(message)s")
-stderr.setLevel(logging.NOTSET)
+stderr.setLevel(logging.WARNING)
 stderr.setFormatter(fmt)
 logging.getLogger().addHandler(stderr)
 logging.getLogger().setLevel(logging.NOTSET)


### PR DESCRIPTION
When a new git branch was created, pushing the branch caused the hook script to fail:
```
remote: fatal: ambiguous argument 'grep': unknown revision or path not in the working tree.
remote: Use '--' to separate paths from revisions, like this:
remote: 'git <command> [<revision>...] -- [<file>...]'
remote: git_buildbot: ERROR: Unhandled exception
```
This was because the `Popen` call in `gen_create_branch_changes()` was invoking a shell command containing pipes and a command substitution which weren't being interpreted as such.  I broke the compound shell command into individual `Popen` calls connected by `subprocess.PIPE`.