### PR TITLE
Add common files for systemd services

### DIFF
--- a/common/contrib/systemd/README.md
+++ b/common/contrib/systemd/README.md
@@ -1,0 +1,14 @@
+# Common files for buildbot systemd services
+
+These files are for creating system users and data directory for buildbot systemd services (`master/contrib/systemd/buildbot@.service` and `worker/contrib/systemd/buildbot-worker@.service`).
+
+## Usage
+
+```
+$ sudo install -Dm644 ./sysusers.d/buildbot.conf /usr/lib/sysusers.d/buildbot.conf
+$ sudo install -Dm644 ./tmpfiles.d/buildbot.conf /usr/lib/tmpfiles.d/buildbot.conf
+$ sudo /usr/bin/systemd-sysusers
+$ sudo /usr/bin/systemd-tmpfiles --create
+```
+
+Packagers may place the last two commands into package post-installation scripts if those are not already in transaction scripts (e.g., dpkg triggers for Debian-based systems or ALPM hooks for Arch-based systems).

--- a/common/contrib/systemd/sysusers.d/buildbot.conf
+++ b/common/contrib/systemd/sysusers.d/buildbot.conf
@@ -1,0 +1,1 @@
+u buildbot - "Buildbot daemon" /var/lib/buildbot

--- a/common/contrib/systemd/tmpfiles.d/buildbot.conf
+++ b/common/contrib/systemd/tmpfiles.d/buildbot.conf
@@ -1,0 +1,1 @@
+d /var/lib/buildbot 0700 buildbot buildbot

--- a/master/contrib/systemd/buildbot@.service
+++ b/master/contrib/systemd/buildbot@.service
@@ -4,6 +4,8 @@
 #   cd /var/lib/buildbot
 #   buildbot create-master [directory]
 #   systemctl enable --now buildbot@[directory].service
+# You may also want to install extra files per common/contrib/systemd/README.md
+# to create the buildbot user/group and the /var/lib/buildbot directory
 [Unit]
 Description=Buildbot Master
 After=network.target

--- a/worker/contrib/systemd/buildbot-worker@.service
+++ b/worker/contrib/systemd/buildbot-worker@.service
@@ -4,6 +4,8 @@
 #   cd /var/lib/buildbot
 #   buildbot-worker create-worker [directory] [master hostname] [name] [password]
 #   systemctl enable --now buildbot-worker@[directory].service
+# You may also want to install extra files per common/contrib/systemd/README.md
+# to create the buildbot user/group and the /var/lib/buildbot directory
 [Unit]
 Description=Buildbot Worker
 After=network.target


### PR DESCRIPTION
Following https://github.com/buildbot/buildbot-contrib/pull/17, adding files for creating the buildbot user/group and its home directory. If this patch is integrated into buildbot packages on Arch Linux, setup a buildbot will be simpler.