### PR TITLE
Fix spurious error when git force push doesn't change any files

### DIFF
--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -287,9 +287,11 @@ def gen_update_branch_changes(oldrev, newrev, refname, branch):
             if not line:
                 break
 
-            file = re.match(r"^:.*[MAD]\s+(.+)$", line).group(1)
-            logging.debug("  Rewound file: %s", file)
-            files.append(text_type(file))
+            m = re.match(r"^:.*[MAD]\s+(.+)$", line)
+            if m:
+                file = m.group(1)
+                logging.debug("  Rewound file: %s", file)
+                files.append(text_type(file))
 
         status = f.wait()
         if status:

--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -162,8 +162,9 @@ def grab_commit_info(c, rev):
 
         m = re.match(r"^:.*[MAD]\s+(.+)$", line)
         if m:
-            logging.debug("Got file: %s", m.group(1))
-            files.append(text_type(m.group(1)))
+            file = m.group(1)
+            logging.debug("Got file: %s", file)
+            files.append(text_type(file))
             continue
 
         m = re.match(r"^Author:\s+(.+)$", line)


### PR DESCRIPTION
The first commit here avoids an error about using `None` object after force-pushing to a branch without changing any file contents (which happens relatively often, e.g. after interactive rebase to squash fixup commits).

The second one is just minor cleanup.